### PR TITLE
Update path for actions/checkout in workflow

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -42,7 +42,7 @@ jobs:
         run: ${{ inputs.extra_cmd }}
       - uses: actions/checkout@v4
         with:
-          path: workdir/${}
+          path: workdir
       - uses: catie-aq/zephyr_workflows/zephyr_build@main
         with:
           application: workdir/${{ inputs.application }}


### PR DESCRIPTION
This pull request updates the path for the actions/checkout step in the workflow. The previous path was set to "workdir/${}", which has been changed to "workdir". This change ensures that the correct directory is checked out for the subsequent steps in the workflow.