### PR TITLE
Update default twister tags for board workflow

### DIFF
--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -6,6 +6,10 @@ on:
       board:
         required: true
         type: string
+      tags:
+        required: false
+        type: string
+        default: "DAC,ieee802154,counter,gpio,serial,i2c,i3c,UART,qspi,pwm,button,usb,spi,lora,i2s,mipi_dbi,wifi,ethernet,nvs,uart,dma,clock_control,usbc,watchdog,dac,w1,input,peci,can,bluetooth,adc,clock"
       extra_cmd:
         required: false
         type: string
@@ -28,7 +32,7 @@ jobs:
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
       ZEPHYR_VERSION: "v3.7.0"
-      TWISTER_OPTIONS: "--force-color --inline-logs -v --clobber-output --integration "
+      TWISTER_OPTIONS: "--force-color --inline-logs -v --clobber-output"
     steps:
       - name: Run Extra Command
         shell: bash
@@ -52,6 +56,7 @@ jobs:
         with:
           board: ${{ inputs.board }}
           options: ${{ env.TWISTER_OPTIONS }}
+          tags: ${{ inputs.tags }}
 
       - name: Clean up
         if: always()

--- a/zephyr_twister/action.yml
+++ b/zephyr_twister/action.yml
@@ -1,7 +1,7 @@
-name: 'Zephyr Twister'
-description: 'Run tests with twister'
+name: "Zephyr Twister"
+description: "Run tests with twister"
 inputs:
-  tag:
+  tags:
     required: false
     type: string
     description: "Test to run"
@@ -34,8 +34,11 @@ runs:
     - name: Run test with twister
       shell: bash
       run: |
-        if [[ -n "${{ inputs.tag }}" ]]; then
-          test="-t  ${{ inputs.tag }}"
+        if [[ -n "${{ inputs.tags }}" ]]; then
+          test=""
+          for tag in $(echo ${{ inputs.tags }} | tr "," "\n"); do
+            test="$test -t $tag"
+          done
         fi
         if [[ -n "${{ inputs.board }}" ]]; then
           board="-p ${{ inputs.board }}"


### PR DESCRIPTION
IC is too long and performs unnecessary tests. This PR reduce the scope of testing and run only necessary tests.