### PR TITLE
Update default Docker image with CATIE Zephyr image

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -15,7 +15,7 @@ on:
       container:
         required: false
         type: string
-        default: "zephyrprojectrtos/ci"
+        default: "ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci"
       pem_key_path:
         required: false
         type: string

--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -9,7 +9,7 @@ on:
       container:
         required: false
         type: string
-        default: "ghcr.io/catie-aq/zephyr_docker:v0.27.4"
+        default: "ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci"
       tags:
         required: false
         type: string

--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -10,7 +10,7 @@ on:
       container:
         required: false
         type: string
-        default: "ghcr.io/catie-aq/zephyr_docker:v0.27.4"
+        default: "ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci"
       extra_cmd:
         required: false
         type: string

--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -9,7 +9,7 @@ on:
       container:
         required: false
         type: string
-        default: "ghcr.io/catie-aq/zephyr_docker:v0.27.4"
+        default: "ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci"
       extra_cmd:
         required: false
         type: string


### PR DESCRIPTION
Updates to Docker container image versions:

* [`.github/workflows/application.yml`](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L18-R18): Changed the default container image to `ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci`.
* [`.github/workflows/board.yml`](diffhunk://#diff-1b2b1bb8d336f9e9ee4d02468a93e1b2f7f57e4188f4d053bb23f963ae1b5242L12-R12): Updated the default container image to `ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci`.
* [`.github/workflows/driver.yml`](diffhunk://#diff-41a89be299f9cb0c0227d7c608e236139b0d6c957809e67e0acb3fa710a88860L13-R13): Updated the default container image to `ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci`.
* [`.github/workflows/shield.yml`](diffhunk://#diff-a0eb997569156ec9bada2f92ba46b8036e861c91d71ee7c7ff1e8429dd2e1458L12-R12): Updated the default container image to `ghcr.io/catie-aq/zephyr_docker:v4.0.0-202502-ci`.