### PR TITLE
Update Zephyr version to v4.1.0

### DIFF
--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -35,7 +35,7 @@ jobs:
       options: --user root --privileged
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
-      ZEPHYR_VERSION: "v4.0.0"
+      ZEPHYR_VERSION: "v4.1.0"
       TWISTER_OPTIONS: "--force-color --inline-logs -v --clobber-output"
     steps:
       - name: Run Extra Command

--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -32,7 +32,7 @@ jobs:
     container: ${{ inputs.container }}
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
-      ZEPHYR_VERSION: "v4.0.0"
+      ZEPHYR_VERSION: "v4.1.0"
       TWISTER_OPTIONS: "--force-color --inline-logs -v --clobber-output --integration "
     steps:
       - name: Extra command

--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -31,7 +31,7 @@ jobs:
       options: --user root --privileged
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
-      ZEPHYR_VERSION: "v4.0.0"
+      ZEPHYR_VERSION: "v4.1.0"
     steps:
       - name: Run Extra Command
         shell: bash


### PR DESCRIPTION
This pull request updates the Zephyr version used in multiple GitHub workflow files to ensure compatibility with the latest features and fixes in Zephyr 4.1.0.

Updates to Zephyr version:

* [`.github/workflows/board.yml`](diffhunk://#diff-1b2b1bb8d336f9e9ee4d02468a93e1b2f7f57e4188f4d053bb23f963ae1b5242L38-R38): Updated `ZEPHYR_VERSION` from "v4.0.0" to "v4.1.0" in the `env` section.
* [`.github/workflows/driver.yml`](diffhunk://#diff-41a89be299f9cb0c0227d7c608e236139b0d6c957809e67e0acb3fa710a88860L35-R35): Updated `ZEPHYR_VERSION` from "v4.0.0" to "v4.1.0" in the `env` section.
* [`.github/workflows/shield.yml`](diffhunk://#diff-a0eb997569156ec9bada2f92ba46b8036e861c91d71ee7c7ff1e8429dd2e1458L34-R34): Updated `ZEPHYR_VERSION` from "v4.0.0" to "v4.1.0" in the `env` section.