### PR TITLE
Add overlay option to zephyr build action

### DIFF
--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -57,3 +57,4 @@ jobs:
           board: zest_core_stm32l4a6rg
           application: zephyr/samples/basic/blinky
           shield: ${{ inputs.shield }}
+          overlay: "${{ inputs.shield|upper|replace('-', '_') }}(1)"

--- a/zephyr_build/action.yml
+++ b/zephyr_build/action.yml
@@ -16,10 +16,19 @@ inputs:
     required: false
     type: string
     default: ""
+  overlay:
+    required: false
+    type: string
+    default: ""
 
 runs:
   using: "composite"
   steps:
+    - name: Overwrite Overlay
+      shell: bash
+      if: ${{ inputs.overlay != '' }}
+      run: echo "${{ inputs.overlay }}" > "${{ inputs.application }}/app.overlay"
+
     - name: Build Zephyr Application
       shell: bash
       if: ${{ inputs.board != '' && inputs.shield != '' }}
@@ -39,3 +48,8 @@ runs:
       shell: bash
       if: ${{ inputs.board == '' && inputs.shield == '' }}
       run: west build ${{ inputs.application }} -p ${{ inputs.extra_args }}
+
+    - name: Remove Overlay
+      shell: bash
+      if: ${{ inputs.overlay != '' }}
+      run: rm "${{ inputs.application }}/app.overlay"


### PR DESCRIPTION
This pull request introduces support for an optional overlay configuration in the Zephyr build process. The changes allow users to specify an overlay file dynamically, which is applied during the build and then removed afterward to maintain a clean workspace.

### Enhancements to Zephyr build workflow:

* **Dynamic overlay support in GitHub Actions workflow**:
  - Updated `.github/workflows/shield.yml` to include an `overlay` parameter derived from the shield input, formatted to match Zephyr's naming conventions.

* **Overlay input and handling in `zephyr_build` action**:
  - Added a new `overlay` input in `zephyr_build/action.yml` to allow users to specify an overlay file.
  - Added a step to write the specified overlay content to `app.overlay` in the application's directory before the build process.
  - Added a cleanup step to remove the `app.overlay` file after the build process is complete.