### PR TITLE
Add cmsis_6 to name-allowlist in driver workflow for Zephyr 4.2.0 compatibility

### DIFF
--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -66,6 +66,7 @@ jobs:
                 import:
                   name-allowlist:
                     - cmsis
+                    - cmsis_6
                     - hal_stm32
               - name: zephyr_zest-core-stm32l4a6rg
                 remote: catie-6tron


### PR DESCRIPTION
This pull request updates the workflow configuration to add `cmsis_6` imports for Zephyr 4.2.0 compatibility.

* Added `cmsis_6` to the `name-allowlist` under `jobs.import` in `.github/workflows/driver.yml`, allowing workflows to accept this new import name.