### PR TITLE
Update modules and boards selection parameter

### DIFF
--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: "samples"
+      zephyr_modules:
+        required: false
+        type: string
+        description: "Comma-separated list of Zephyr modules to include in name-allowlist (e.g., 'cmsis,cmsis_6,hal_stm32')"
+        default: "hal_stm32"
     secrets:
       personal_access_token:
         required: true
@@ -67,7 +72,19 @@ jobs:
                   name-allowlist:
                     - cmsis
                     - cmsis_6
-                    - hal_stm32
+          EOF
+          
+          # Add Zephyr modules from the zephyr_modules input parameter
+          IFS=',' read -ra MODULES <<< "${{ inputs.zephyr_modules }}"
+          for module in "${MODULES[@]}"; do
+            module=$(echo "$module" | xargs)  # Trim whitespace
+            if [ -n "$module" ]; then
+              echo "          - $module" >> workdir/west.yml
+            fi
+          done
+          
+          # Add other projects
+          cat << EOF >> workdir/west.yml
               - name: zephyr_zest-core-stm32l4a6rg
                 remote: catie-6tron
                 revision: main

--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -3,7 +3,7 @@ name: Build & Test Zephyr Driver
 on:
   workflow_call:
     inputs:
-      board:
+      boards:
         required: false
         type: string
         default: "zest_core_stm32l4a6rg"
@@ -82,15 +82,20 @@ jobs:
               echo "          - $module" >> workdir/west.yml
             fi
           done
+
+          IFS=',' read -ra BOARDS <<< "${{ inputs.boards }}"
+          for board in "${BOARDS[@]}"; do
+            board=$(echo "$board" | xargs)  # Trim whitespace
+            board=${board//_/-} # Replace underscores with hyphens
+            if [ -n "$board" ]; then
+              echo "    - name: zephyr_$board" >> workdir/west.yml
+              echo "      remote: catie-6tron" >> workdir/west.yml
+              echo "      revision: main" >> workdir/west.yml
+            fi
+          done
           
           # Add other projects
           cat << EOF >> workdir/west.yml
-              - name: zephyr_zest-core-stm32l4a6rg
-                remote: catie-6tron
-                revision: main
-              - name: zephyr_zest-core-nrf5340
-                remote: catie-6tron
-                revision: main
               - name: zephyr_6tron-connector
                 remote: catie-6tron
                 revision: main

--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ Ce workflow applique les étapes suivantes :
 - Génération du fichier `west.yml` pour le projet Zephyr en utilisant l'action Generate Zephyr Manifest
 - Test de compilation du driver en utilisant l'action Zephyr Build
 
-| Input                   | Description                                                             | Obligatoire | Default                          |
-| ----------------------- | ----------------------------------------------------------------------- | :---------: | -------------------------------- |
-| `application`           | Chemin de l'application à compiler.                                     |     Non     | `"samples"`                      |
-| `board`                 | Cible à utiliser pour la compilation.                                   |     Non     | `"zest_core_stm32l4a6rg"`        |
-| `container`             | Image Docker à utiliser pour l'exécution des commandes.                 |     Non     | `"zephyrprojectrtos/ci"`         |
-| `extra_cmd`             | Commandes supplémentaires à exécuter avant la compilation.              |     Non     | ``                               |
-| `personal_access_token` | Token d'accès personnel (PAT) à utiliser pour cloner les dépôts privés. |     Oui     |                                  |
+| Input                   | Description                                                                          | Obligatoire | Default                          |
+| ----------------------- | ------------------------------------------------------------------------------------ | :---------: | -------------------------------- |
+| `path`                  | Chemin de l'application à compiler.                                                  |     Non     | `"samples"`                      |
+| `boards`                | Liste des cibles à utiliser pour la compilation, séparées par des virgules.          |     Non     | `"zest_core_stm32l4a6rg"`        |
+| `container`             | Image Docker à utiliser pour l'exécution des commandes.                              |     Non     | `"zephyrprojectrtos/ci"`         |
+| `extra_cmd`             | Commandes supplémentaires à exécuter avant la compilation.                           |     Non     | ``                               |
+| `zephyr_modules`        | Liste des modules Zephyr à inclure dans le name-allowlist, séparés par des virgules. |     Non     | `"hal_stm32"`                    |
+| `personal_access_token` | Token d'accès personnel (PAT) à utiliser pour cloner les dépôts privés.              |     Oui     |                                  |
 
 ```yaml
 name: "Zephyr Driver CI/CD"


### PR DESCRIPTION
This pull request updates the Zephyr driver GitHub Actions workflow to make it more flexible and configurable. The main improvements are the ability to specify multiple boards and Zephyr modules dynamically through workflow inputs.

**Workflow input enhancements:**

* Changed the `board` input to `boards`, allowing users to specify a comma-separated list of boards instead of just one.
* Added a new `zephyr_modules` input, enabling users to provide a comma-separated list of Zephyr modules to include in the build configuration.

**Dynamic configuration generation:**

* Updated the script that generates the `workdir/west.yml` file to dynamically add Zephyr modules from the `zephyr_modules` input, instead of hardcoding them.
* Modified the script to iterate over the list of boards from the `boards` input, adding each board to the configuration with the correct naming and formatting.