### PR TITLE
Import driver submodule

### DIFF
--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -25,6 +25,11 @@ on:
         type: string
         description: "Comma-separated list of Zephyr modules to include in name-allowlist (e.g., 'cmsis,cmsis_6,hal_stm32')"
         default: "hal_stm32"
+      has_manifest:
+        required: false
+        type: boolean
+        description: "Import the driver's manifest (west.yml)"
+        default: false
     secrets:
       personal_access_token:
         required: true
@@ -102,8 +107,12 @@ jobs:
               - name: ${{ github.event.repository.name }}
                 remote: catie-6tron
                 revision: ${{ steps.branch-names.outputs.current_branch }}
-                import: true
           EOF
+          
+          # Add import: true conditionally if has_manifest is true
+          if [ "${{ inputs.has_manifest }}" = "true" ]; then
+            echo "            import: true" >> workdir/west.yml
+          fi
 
       - uses: catie-aq/zephyr_workflows/zephyr_init@main
         with:

--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -102,6 +102,7 @@ jobs:
               - name: ${{ github.event.repository.name }}
                 remote: catie-6tron
                 revision: ${{ steps.branch-names.outputs.current_branch }}
+                import: true
           EOF
 
       - uses: catie-aq/zephyr_workflows/zephyr_init@main

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Ce workflow applique les étapes suivantes :
 | `container`             | Image Docker à utiliser pour l'exécution des commandes.                              |     Non     | `"zephyrprojectrtos/ci"`         |
 | `extra_cmd`             | Commandes supplémentaires à exécuter avant la compilation.                           |     Non     | ``                               |
 | `zephyr_modules`        | Liste des modules Zephyr à inclure dans le name-allowlist, séparés par des virgules. |     Non     | `"hal_stm32"`                    |
+| `has_manifest`          | Indique si le driver contient un manifest `west.yml` ou non.                         |     Non     | `false`                           |
 | `personal_access_token` | Token d'accès personnel (PAT) à utiliser pour cloner les dépôts privés.              |     Oui     |                                  |
 
 ```yaml


### PR DESCRIPTION
This pull request enhances the driver workflow by introducing support for drivers that include a `west.yml` manifest file. It adds a new input to the workflow to indicate the presence of a manifest and updates the documentation accordingly.

**Workflow input and behavior updates:**

* Added a new optional boolean input `has_manifest` to `.github/workflows/driver.yml` to indicate if the driver contains a `west.yml` manifest.
* Updated the workflow logic to conditionally append `import: true` to `west.yml` if `has_manifest` is set to true.

**Documentation:**

* Updated `README.md` to document the new `has_manifest` input, explaining its purpose and default value.